### PR TITLE
About Us - image-box & text-box

### DIFF
--- a/resources/views/components/layouts/image-box.blade.php
+++ b/resources/views/components/layouts/image-box.blade.php
@@ -1,0 +1,105 @@
+@php
+    $variantClasses = [
+        'ver-1' => 'flex flex-wrap justify-center gap-8',
+        'ver-2' => 'flex items-center justify-center w-full',
+        'ver-3' => 'flex items-center justify-center w-full flex-row-reverse',
+        'ver-4' => 'flex items-center justify-center w-full',
+    ];
+
+    $boxSizeClass = 'w-[97%] h-[97%]';
+@endphp
+{{-- VARIANTS ARE DIRECTLY FROM THE FIGMA DESIGNS IN DRAFT #2 --}}
+
+{{-- Image Setting for ver-1--}}
+{{--
+    @php
+        // First, define the array of images you want to display
+        $galleryImages = [
+            [
+                'src' => 'add source ref here',
+                'alt' => 'A forest path'
+            ],
+            [
+                'src' => 'add source ref here',
+                'alt' => 'A misty mountain range'
+            ]
+        ];
+    @endphp
+
+        //Then, pass that array to the component using the :images prop
+
+        <x-layouts.image-box variant="ver-1" :images="$galleryImages" />
+
+--}}
+
+{{-- Image Setting for ver-2,3,& 4--}}
+
+{{-- @php
+            // Similar to the center image boxes, define the single image you want to display
+            $portraitImage = [
+                'src' => 'add source ref here',
+                'alt' => 'A beautiful beach scene'
+            ];
+
+            //Create more if different images are needed for the each image boxes.
+        @endphp
+
+            // After that, pass that single image array to the component using the :image prop
+
+            <x-layouts.image-box variant="ver-3" :image="$portraitImage" />
+ --}}
+
+
+
+@php
+    $variant = $variant ?? 'ver-1';
+@endphp
+<div class="{{ $variantClasses[$variant] ?? $variantClasses['ver-1'] }}">
+    @if($variant === 'ver-1') {{-- Two Center Photobox --}}
+
+        @foreach($images ?? [] as $image)
+            <div class="relative w-full md:w-1/2 max-w-lg aspect-video">
+                {{-- Background Box --}}
+                <div class="absolute top-0 left-0 {{ $boxSizeClass }}" style="background-color: #0ABAB5;"></div>
+
+                {{-- Foreground Box with Image --}}
+                <div class="absolute bottom-0 right-0 {{ $boxSizeClass }} flex items-center justify-center text-gray-500 text-sm" style="background-color: #FFF; border: 0.36px solid #056360;">
+                    <img src="{{ $image['src'] ?? '' }}"
+                         alt="{{ $image['alt'] ?? 'Placeholder Image' }}"
+                         class="w-full h-full object-cover">
+                </div>
+            </div>
+        @endforeach
+    @else
+        @php
+            $containerClasses = [
+                'ver-2' => 'relative w-full max-w-3xl aspect-video',
+                'ver-3' => 'relative w-full max-w-lg aspect-[4/5]',
+                'ver-4' => 'relative w-full max-w-md aspect-[4/5]',
+            ][$variant] ?? '';
+
+            $bgBoxClasses = [
+                'ver-2' => 'absolute top-0 left-0',
+                'ver-3' => 'absolute top-0 right-0',
+                'ver-4' => 'absolute top-0 left-0',
+            ][$variant] ?? '';
+
+            $fgBoxClasses = [
+                'ver-2' => 'absolute bottom-0 right-0',
+                'ver-3' => 'absolute bottom-0 left-0',
+                'ver-4' => 'absolute bottom-0 right-0',
+            ][$variant] ?? '';
+        @endphp
+        <div class="{{ $containerClasses }}">
+            {{-- Background Box --}}
+            <div class="{{ $bgBoxClasses }} {{ $boxSizeClass }}" style="background-color: #0ABAB5;"></div>
+
+            {{-- Foreground Box with Image --}}
+            <div class="{{ $fgBoxClasses }} {{ $boxSizeClass }} flex items-center justify-center text-gray-500 text-sm" style="background-color: #FFF; border: 0.36px solid #056360;">
+                <img src="{{ $image['src'] ?? '' }}"
+                     alt="{{ $image['alt'] ?? 'Placeholder Image' }}"
+                     class="w-full h-full object-cover">
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/components/layouts/text-box.blade.php
+++ b/resources/views/components/layouts/text-box.blade.php
@@ -1,0 +1,123 @@
+@php
+    // Defines the alignment for the entire component container.
+    $variantClasses = [
+        'ver-1' => 'flex justify-center items-center w-full',
+        'ver-2' => 'flex items-center justify-center w-full',
+        'ver-3' => 'flex items-center justify-center w-full flex-row-reverse',
+        'ver-4' => 'flex items-center justify-center w-full',
+        'ver-5' => 'flex items-center justify-center w-full',
+        'ver-6' => 'flex items-center justify-center w-full',
+    ];
+
+    // The size of the foreground/background boxes relative to their container.
+    // This creates the offset effect.
+    $boxSizeClass = 'w-[97%] h-[97%]';
+@endphp
+
+{{--
+    This component creates a stylized text box with a background and foreground element.
+    It supports 6 different variants.
+
+    HOW TO USE:
+    Pass the content directly into the component's slot.
+
+    <x-layouts.text-box variant="ver-1">
+        Your content, like this paragraph, goes here. It will be placed inside the foreground box.
+    </x-layouts.text-box>
+--}}
+
+@php
+    // Sets a default variant if none is provided.
+    $variant = $variant ?? 'ver-1';
+@endphp
+
+<div class="{{ $variantClasses[$variant] ?? $variantClasses['ver-1'] }}">
+    @if ($variant === 'ver-1')
+        <div class="relative w-full max-w-5xl aspect-[1245/264] p-2">
+            {{-- Background Box --}}
+            <div class="absolute bottom-3 {{ $boxSizeClass }} rounded-[60px] border-[4px]" style="border-color: #0ABAB5;"></div>
+
+            {{-- Foreground Box with Text --}}
+            <div class="absolute top-3 {{ $boxSizeClass }} flex items-center justify-center rounded-[60px] border-[4px] p-6 md:p-10" style="border-color: #056360;">
+                <div class="font-poppins text-center font-light text-2xl leading-8"
+                    style="color: #056360; text-align: center; font-family: Poppins; font-size: 24px; font-style: normal; font-weight: 300; line-height: 32px;">
+                    {{ $slot }}
+                </div>
+            </div>
+        </div>
+@elseif ($variant === 'ver-4')
+    <div class="relative w-full max-w-3xl aspect-video p-2">
+        {{-- Foreground Box with Text --}}
+        <div class="absolute top-3 flex items-center justify-center rounded-2xl" style="background-color: #0ABAB5; width: 345px; height: 305px;">
+            <div class="font-poppins text-center font-light text-2xl leading-8" style="color: #FFF; text-align: center; font-family: Poppins; font-size: 24px; font-style: normal; font-weight: 300; line-height: 32px;">
+                {{ $slot }}
+            </div>
+        </div>
+    </div>
+@elseif ($variant === 'ver-5')
+    <div class="relative w-full max-w-3xl aspect-video p-2">
+        {{-- Foreground Box with Text --}}
+        <div class="absolute top-3 flex items-center justify-center rounded-2xl border-[4px] p-6 md:p-8" style="border-color: #0ABAB5; background-color: #FFF; width: 345px; height: 305px;">
+            <div class="font-poppins text-center font-light text-2xl leading-8" style="color: #056360; text-align: center; font-family: Poppins; font-size: 24px; font-style: normal; font-weight: 300; line-height: 32px;">
+                {{ $slot }}
+            </div>
+        </div>
+    </div>
+@elseif ($variant === 'ver-6')
+    <div class="relative w-full max-w-3xl aspect-video p-2">
+        {{-- Foreground Box with Text --}}
+        <div class="absolute top-3 flex items-center justify-center rounded-2xl border-[4px] p-6 md:p-8" style="border-color: #0ABAB5; width: 838.125px; height: 439.688px;">
+            <div class="font-poppins text-center font-light text-2xl leading-8" style="color: #056360;">
+            {{ $slot }}
+            </div>
+        </div>
+    </div>
+@else
+    {{-- Variants 2-3: Now styled with two borders and a transparent background. --}}
+    @php
+        // Defines the shape and size of the container for each variant.
+        $containerClasses = [
+            'ver-2' => 'relative w-[727.984px] h-[283px]', // Custom fixed size
+            'ver-3' => 'relative w-[942px] h-[259px]',      // Custom fixed size
+        ][$variant];
+
+        // Defines the position of the background box.
+        $bgBoxClasses = [
+            'ver-2' => 'absolute top-0 left-0',
+            'ver-3' => 'absolute top-0 left-0',
+        ][$variant];
+
+        // Defines the position of the foreground box.
+        $fgBoxClasses = [
+            'ver-2' => 'absolute bottom-0 right-0',
+            'ver-3' => 'absolute bottom-0 right-0',
+        ][$variant];
+
+        $bgBoxStyle = '';
+        $fgBoxStyle = 'border-color: #056360;';
+        $bgBoxRadius = 'rounded-2xl';
+        $fgBoxRadius = 'rounded-2xl';
+
+        if ($variant === 'ver-2') {
+            $bgBoxStyle = 'border-color: #0ABAB5; width: 727.984px; height: 283px;';
+            $fgBoxStyle .= ' width: 727.984px; height: 283px;';
+        } elseif ($variant === 'ver-3') {
+            $bgBoxStyle = 'border-color: #0ABAB5;';
+            $bgBoxRadius = 'rounded-[60px]';
+            $fgBoxRadius = 'rounded-[60px]';
+        }
+        @endphp
+
+        <div class="{{ $containerClasses }}">
+        {{-- Background Box (Now a border) --}}
+        <div class="{{ $bgBoxClasses }} {{ $boxSizeClass }} {{ $bgBoxRadius }} border-[4px] p-6 md:p-8" style="{{ $bgBoxStyle }}"></div>
+
+        {{-- Foreground Box with Text (Thicker border) --}}
+        <div class="{{ $fgBoxClasses }} {{ $boxSizeClass }} flex items-center justify-center {{ $fgBoxRadius }} border-[4px] p-6 md:p-8" style="{{ $fgBoxStyle }}">
+            <div class="font-poppins text-center font-light text-2xl leading-8" style="color: #056360;">
+            {{ $slot }}
+            </div>
+        </div>
+        </div>
+    @endif
+    </div>


### PR DESCRIPTION
**Addition**

- Added reusable image-box blade component.
- Provides a styled container for displaying images with layered background/foreground divs.
- Added reusable text-box blade component.
- Foreground div includes typography styling (Poppins, #056360, centered alignment).

**Questions**

- Should the section titles (e.g., About Us, Our Mission, Our Vision) be included inside this text-box blade, or should they be handled as a separate title component?